### PR TITLE
 Correctly display s3 url based on documentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,7 +250,7 @@ class Client {
         fileKey    = filePath.replace(_this.clientPath, '').substr(1).replace(/\\/g, '/');
 
     this.serverless.cli.log(`Uploading file ${fileKey} to bucket ${_this.bucketName}...`);
-    this.serverless.cli.log(`If successful this should be deployed at: https://s3.amazonaws.com/${_this.bucketName}/${fileKey}`)
+    this.serverless.cli.log(`If successful this should be deployed at: https://s3-${_this.region}.amazonaws.com/${_this.bucketName}/${fileKey}`)
 
     fs.readFile(filePath, function(err, fileBuffer) {
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,24 @@ const _            = require('lodash');
 const mime         = require('mime');
 const fs           = require('fs');
 
+// per http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
+const regionToUrlRootMap = region => ({
+  'us-east-2': 's3-website.us-east-2.amazonaws.com',
+  'us-east-1': 's3-website-us-east-1.amazonaws.com',
+  'us-west-1': 's3-website-us-west-1.amazonaws.com',
+  'us-west-2': 's3-website-us-west-2.amazonaws.com',
+  'ca-central-1': 's3-website.ca-central-1.amazonaws.com',
+  'ap-south-1': 's3-website.ap-south-1.amazonaws.com',
+  'ap-northeast-2': 's3-website.ap-northeast-2.amazonaws.com',
+  'ap-southeast-1': 's3-website-ap-southeast-1.amazonaws.com',
+  'ap-southeast-2': 's3-website-ap-southeast-2.amazonaws.com',
+  'ap-northeast-1': 's3-website-ap-northeast-1.amazonaws.com',
+  'eu-central-1': 's3-website.eu-central-1.amazonaws.com',
+  'eu-west-1': 's3-website-eu-west-1.amazonaws.com',
+  'eu-west-2': 's3-website.eu-west-2.amazonaws.com',
+  'sa-east-1': 's3-website-sa-east-1.amazonaws.com',
+}[region])
+
 class Client {
   constructor(serverless, options){
     this.serverless = serverless;
@@ -247,10 +265,13 @@ class Client {
 
   _uploadFile(filePath) {
     let _this      = this,
-        fileKey    = filePath.replace(_this.clientPath, '').substr(1).replace(/\\/g, '/');
+        fileKey    = filePath.replace(_this.clientPath, '').substr(1).replace(/\\/g, '/'),
+        urlRoot    = regionToUrlRootMap(_this.region);
 
     this.serverless.cli.log(`Uploading file ${fileKey} to bucket ${_this.bucketName}...`);
-    this.serverless.cli.log(`If successful this should be deployed at: https://s3-${_this.region}.amazonaws.com/${_this.bucketName}/${fileKey}`)
+    this.serverless.cli.log('If successful this should be deployed at:')
+    this.serverless.cli.log(`https://${urlRoot}/${_this.bucketName}/${fileKey}`)
+    this.serverless.cli.log(`http://${_this.bucketName}.${urlRoot}/${fileKey}`)
 
     fs.readFile(filePath, function(err, fileBuffer) {
 


### PR DESCRIPTION
* Correctly display s3 url based on the formats laid out for specific regions in the documentation.
* Add a log the subdomained version of the url

These changes were made according to the documentation on these pages:
* http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html
* http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html
* http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints